### PR TITLE
Replace task_scheduler with global_control

### DIFF
--- a/SniperMuster/src/ModuleDef.cc
+++ b/SniperMuster/src/ModuleDef.cc
@@ -57,7 +57,7 @@ struct GlobalStreamBaseWrap : GlobalStreamBase, bp::wrapper<GlobalStreamBase>
 
     SniperJSON json()
     {
-        this->get_override("json")();
+        return this->get_override("json")();
     }
 };
 

--- a/SniperMuster/src/Muster.cc
+++ b/SniperMuster/src/Muster.cc
@@ -1,17 +1,17 @@
 /* Copyright (C) 2018-2021
    Institute of High Energy Physics and Shandong University
    This file is part of mt.sniper.
- 
+
    mt.sniper is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
- 
+
    mt.sniper is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU Lesser General Public License for more details.
- 
+
    You should have received a copy of the GNU Lesser General Public License
    along with mt.sniper.  If not, see <http://www.gnu.org/licenses/>. */
 
@@ -24,7 +24,7 @@
 #include "SniperKernel/SniperException.h"
 #include "SniperKernel/SniperLog.h"
 #include <tbb/task.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/global_control.h>
 #include <boost/python.hpp>
 
 namespace bp = boost::python;
@@ -89,7 +89,7 @@ bool Muster::run()
 {
     sniper_context->set_threads(m_threads);
 
-    tbb::task_scheduler_init scheduler_init(m_threads);
+    tbb::global_control thread_control(tbb::global_control::max_allowed_parallelism, m_threads);
 
     SyncAssistor::run();
 


### PR DESCRIPTION
 1. In Muster.cc: Replace task_scheduler with global_control to adapt to the new version of tbb;
 2. In Modudef.cc: Fixed a small bug that the function "json()" didn't have a return value.